### PR TITLE
2017 Outback Limited 3.6r FPv2

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -22,11 +22,7 @@ class CarState(CarStateBase):
     ret.brakePressed = cp.vl["Brake_Pedal"]['Brake_Pedal'] > 1e-5
     ret.brakeLights = ret.brakePressed
 
-    ret.wheelSpeeds.fl = cp.vl["Wheel_Speeds"]['FL'] * CV.KPH_TO_MS
-    ret.wheelSpeeds.fr = cp.vl["Wheel_Speeds"]['FR'] * CV.KPH_TO_MS
-    ret.wheelSpeeds.rl = cp.vl["Wheel_Speeds"]['RL'] * CV.KPH_TO_MS
-    ret.wheelSpeeds.rr = cp.vl["Wheel_Speeds"]['RR'] * CV.KPH_TO_MS
-    ret.vEgoRaw = (ret.wheelSpeeds.fl + ret.wheelSpeeds.fr + ret.wheelSpeeds.rl + ret.wheelSpeeds.rr) / 4.
+    ret.vEgoRaw = cp.vl["Brake_Pedal"]['Speed'] * CV.KPH_TO_MS
     # Kalman filter, even though Subaru raw wheel speed is heaviliy filtered by default
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
     ret.standstill = ret.vEgoRaw < 0.01
@@ -125,6 +121,7 @@ class CarState(CarStateBase):
       ("Cruise_On", "CruiseControl", 0),
       ("Cruise_Activated", "CruiseControl", 0),
       ("Brake_Pedal", "Brake_Pedal", 0),
+      ("Speed", "Brake_Pedal", 0),
       ("Throttle_Pedal", "Throttle", 0),
       ("LEFT_BLINKER", "Dashlights", 0),
       ("RIGHT_BLINKER", "Dashlights", 0),

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -99,7 +99,7 @@ FINGERPRINTS = {
 }
 
 # Use only FPv2
-IGNORED_FINGERPRINTS = [CAR.IMPREZA]
+IGNORED_FINGERPRINTS = [CAR.IMPREZA, CAR.OUTBACK]
 
 FW_VERSIONS = {
   CAR.IMPREZA: {
@@ -166,6 +166,7 @@ FW_VERSIONS = {
       b'\x5b\xb0\x00\x00',
       b'\x5b\xf7\xbc\x03',
       b'[\xf7\xac\x03',
+      b'{\x9a\xac\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x6b\xb0\x00\x00',
@@ -184,18 +185,21 @@ FW_VERSIONS = {
       b'\xf1\x00\xf0\xe0\x0e',
       b'\x00\x00c\x94\x00\x00\x00\x00',
       b'\x00\x00c\x94\x1f@\x10\b',
+      b'\x00\x00c\xec\x1f@ \x04',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xb4\x2b\x40\x70\x07',
       b'\xab\x22\x40\x40\x07',
       b'\xa0\x62\x41\x71\x07',
       b'\xa0*@q\a',
+      b'\xb4+@p\a',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xf1\x00\xa4\x10\x40',
       b'\xbe\xf2\x40\x80\x00',
       b'\xbf\xe2\x40\x80\x00',
       b'\xbf\xf2@\x80\x00',
+      b'\xbd\xfb\xe0\x80\x00',
     ],
   },
 }


### PR DESCRIPTION
Updated FPv2 for 2017 Outback Limited 3.6r FPv2. Tested with a few short drives with no issues. 