### PR TITLE
Added FW for 2018 Outback Premium 2.5i UDM

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -183,6 +183,7 @@ FW_VERSIONS = {
     ],
   },
   CAR.OUTBACK_PREGLOBAL: {
+    # 2018 Outback Premium 2.5i - UDM / @zhoux260
     # 2017 Outback Limited 3.6r - UDM / @Anthony
     # 2016 Outback Limited 2.5 - UDM / @aeiro
     # 2015 Outback Limited 2.5 - ADM / @Bugsy
@@ -194,12 +195,14 @@ FW_VERSIONS = {
       b'k\x97\xac\x00',
       b'\x5b\xf7\xbc\x03',
       b'[\xf7\xac\x03',
+      b'\x8b\x97\xac\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'k\xb0\x00\x00',
       b'[\xb0\x00\x00',
       b'\x4b\xb0\x00\x02',
       b'K\xb0\x00\x00',
+      b'{\xb0\x00\x00',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00c\xec\x1f@ \x04',
@@ -208,6 +211,7 @@ FW_VERSIONS = {
       b'\x00\x00c\x94\x00\x00\x00\x00',
       b'\x00\x00c\x94\x1f@\x10\b',
       b'\x00\x00c\xb7\x1f@\x10\x16',
+      b'\x00\x00df\x1f@ \n',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xb4+@p\a',
@@ -215,6 +219,7 @@ FW_VERSIONS = {
       b'\xa0\x62\x41\x71\x07',
       b'\xa0*@q\a',
       b'\xab*@@\a',
+      b'\xb5"@p\a',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xbd\xfb\xe0\x80\x00',
@@ -222,6 +227,7 @@ FW_VERSIONS = {
       b'\xbf\xe2\x40\x80\x00',
       b'\xbf\xf2@\x80\x00',
       b'\xbe\xf2@p\x00',
+      b'\xbc\xf2@\x81\x00',
     ],
   },
 }


### PR DESCRIPTION
This is a pull request containing zhoux260's 2018 Outback Premium 2.5i (UDM) firmware for FPv2.

Car FW dump:
```
carFw = [
      (ecu = engine, fwVersion = "\xb5"@p\a", address = 2016, subAddress = 0),
      ( ecu = transmission,
        fwVersion = "\xbc\xf2@\x81\x00",
        address = 2017,
        subAddress = 0 ),
      ( ecu = eps,
        fwVersion = "{\xb0\x00\x00",
        address = 1862,
        subAddress = 0 ),
      ( ecu = esp,
        fwVersion = "\x8b\x97\xac\x00",
        address = 1968,
        subAddress = 0 ),
      ( ecu = fwdCamera,
        fwVersion = "\x00\x00df\x1f@ \n",
        address = 1927,
        subAddress = 0 ) ]
```