### PR TITLE
Adding support for Subaru Impreza 2020 and 2021

### DIFF
--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -6,7 +6,7 @@ from opendbc.can.packer import CANPacker
 
 class CarControllerParams():
   def __init__(self):
-    self.STEER_MAX = 2047              # max_steer 4095
+    self.STEER_MAX = 1439              # max_steer 4095
     self.STEER_STEP = 2                # how often we update the steer cmd
     self.STEER_DELTA_UP = 50           # torque increase per refresh, 0.8s to max
     self.STEER_DELTA_DOWN = 70         # torque decrease per refresh
@@ -42,7 +42,7 @@ class CarController():
       apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.params)
       self.steer_rate_limited = new_steer != apply_steer
 
-      if not enabled:
+      if not enabled or CS.out.steerWarning:
         apply_steer = 0
 
       if CS.CP.carFingerprint in PREGLOBAL_CARS:

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -6,6 +6,8 @@ from opendbc.can.packer import CANPacker
 
 class CarControllerParams():
   def __init__(self):
+    #@letdudiss 18 Nov 2020 Reduced max steer for new Subarus (Impreza 2021) with lower torque limit
+    #Avoids LKAS and ES fault when OP apply a steer value exceed what ES allows
     self.STEER_MAX = 1439              # max_steer 4095
     self.STEER_STEP = 2                # how often we update the steer cmd
     self.STEER_DELTA_UP = 50           # torque increase per refresh, 0.8s to max
@@ -42,6 +44,9 @@ class CarController():
       apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.params)
       self.steer_rate_limited = new_steer != apply_steer
 
+    #@letdudiss 18 Nov 2020 Work around for steerWarning to
+    #Avoids LKAS and ES fault when OP apply a steer value exceed what ES allows
+    #set Steering value to 0 when a steer Warning is present
       if not enabled or CS.out.steerWarning:
         apply_steer = 0
 

--- a/selfdrive/car/subaru/carcontroller.py
+++ b/selfdrive/car/subaru/carcontroller.py
@@ -1,6 +1,6 @@
 from selfdrive.car import apply_std_steer_torque_limits
 from selfdrive.car.subaru import subarucan
-from selfdrive.car.subaru.values import DBC, PREGLOBAL_CARS
+from selfdrive.car.subaru.values import DBC, PREGLOBAL_CARS, REDUCED_TORQUE_CARS
 from opendbc.can.packer import CANPacker
 
 
@@ -8,7 +8,10 @@ class CarControllerParams():
   def __init__(self):
     #@letdudiss 18 Nov 2020 Reduced max steer for new Subarus (Impreza 2021) with lower torque limit
     #Avoids LKAS and ES fault when OP apply a steer value exceed what ES allows
-    self.STEER_MAX = 1439              # max_steer 4095
+    if CS.CP.carFingerprint in REDUCED_TORQUE_CARS:
+      self.STEER_MAX = 1439            # max_steer for cars with reduced torque limits
+    else:
+      self.STEER_MAX = 2047            # max_steer 4095
     self.STEER_STEP = 2                # how often we update the steer cmd
     self.STEER_DELTA_UP = 50           # torque increase per refresh, 0.8s to max
     self.STEER_DELTA_DOWN = 70         # torque decrease per refresh
@@ -47,7 +50,7 @@ class CarController():
     #@letdudiss 18 Nov 2020 Work around for steerWarning to
     #Avoids LKAS and ES fault when OP apply a steer value exceed what ES allows
     #set Steering value to 0 when a steer Warning is present
-      if not enabled or CS.out.steerWarning:
+      if not enabled or (CS.out.steerWarning and CS.CP.carFingerprint in REDUCED_TORQUE_CARS):
         apply_steer = 0
 
       if CS.CP.carFingerprint in PREGLOBAL_CARS:

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -47,6 +47,8 @@ class CarState(CarStateBase):
     ret.steeringTorque = cp.vl["Steering_Torque"]['Steer_Torque_Sensor']
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD[self.car_fingerprint]
 
+    #@letdudiss 18 Nov 2020 Avoids LKAS and ES fault when OP apply a steer value exceed what ES allows
+    #Add steer warning to car state update to allow apply_steer 0 when steer max torque warning occurs
     ret.steerWarning = bool(cp.vl["Steering_Torque"]['Steer_Warning'])
 
     ret.cruiseState.enabled = cp.vl["CruiseControl"]['Cruise_Activated'] != 0

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -47,6 +47,8 @@ class CarState(CarStateBase):
     ret.steeringTorque = cp.vl["Steering_Torque"]['Steer_Torque_Sensor']
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD[self.car_fingerprint]
 
+    ret.steerWarning = bool(cp.vl["Steering_Torque"]['Steer_Warning'])
+
     ret.cruiseState.enabled = cp.vl["CruiseControl"]['Cruise_Activated'] != 0
     ret.cruiseState.available = cp.vl["CruiseControl"]['Cruise_On'] != 0
     ret.cruiseState.speed = cp_cam.vl["ES_DashStatus"]['Cruise_Set_Speed'] * CV.KPH_TO_MS
@@ -84,6 +86,7 @@ class CarState(CarStateBase):
       # sig_name, sig_address, default
       ("Steer_Torque_Sensor", "Steering_Torque", 0),
       ("Steering_Angle", "Steering_Torque", 0),
+      ("Steer_Warning", "Steering_Torque", 0),
       ("Cruise_On", "CruiseControl", 0),
       ("Cruise_Activated", "CruiseControl", 0),
       ("Brake_Pedal", "Brake_Pedal", 0),

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -29,7 +29,7 @@ class CarInterface(CarInterfaceBase):
 
     ret.enableCamera = True
 
-    ret.steerRateCost = 0.7
+    ret.steerRateCost = 1
     ret.steerLimitTimer = 0.4
 
     if candidate == CAR.ASCENT:
@@ -43,14 +43,14 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.0025, 0.1], [0.00025, 0.01]]
 
     if candidate == CAR.IMPREZA:
-      ret.mass = 1568. + STD_CARGO_KG
+      ret.mass = 1480. + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
-      ret.steerRatio = 15
-      ret.steerActuatorDelay = 0.4   # end-to-end angle controller
-      ret.lateralTuning.pid.kf = 0.00005
-      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
+      ret.steerRatio = 13
+      ret.steerActuatorDelay = 0.1   # end-to-end angle controller
+      ret.lateralTuning.pid.kf = 0.00003
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 10., 20., 30.], [0., 10., 20., 30.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.01, 0.05, 0.2, 0.21], [0.0010, 0.004, 0.008, 0.009]]
 
     if candidate == CAR.FORESTER:
       ret.mass = 1568. + STD_CARGO_KG

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -42,7 +42,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.0025, 0.1], [0.00025, 0.01]]
 
-    if candidate == CAR.IMPREZA:
+    if candidate in [CAR.IMPREZA, CAR.IMPREZA_2020_2021]:
       ret.mass = 1480. + STD_CARGO_KG
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -70,7 +70,7 @@ FINGERPRINTS = {
 }
 
 # Use only FPv2
-IGNORED_FINGERPRINTS = [CAR.IMPREZA, CAR.ASCENT, CAR.FORESTER_HYBRID]
+IGNORED_FINGERPRINTS = [CAR.IMPREZA, CAR.IMPREZA_2020_2021, CAR.ASCENT, CAR.FORESTER_HYBRID]
 
 FW_VERSIONS = {
   CAR.ASCENT: {
@@ -111,6 +111,24 @@ FW_VERSIONS = {
       b'\x1a\xf6F`\x00',
     ],
   },
+  CAR.IMPREZA_2020_2021: {
+    # 2021 Impreza - AUDM / @letsdudiss
+    (Ecu.esp, 0x7b0, None): [
+      b'\xa2 !5\x00',
+    ],
+    (Ecu.eps, 0x746, None): [
+      b'\x9a\xc0\b\x00',
+    ],
+    (Ecu.fwdCamera, 0x787, None): [
+      b'\xf1\x00\x00\x00\x02',
+    ],
+    (Ecu.engine, 0x7e0, None): [
+      b'\xcaac0\a',
+    ],
+    (Ecu.transmission, 0x7e1, None): [
+      b'\xe6\x15\x042\x00',
+    ],
+  },
   CAR.IMPREZA: {
     # 2018 Crosstrek - EDM / @martinl
     # 2018 Impreza - ADM / @Michael
@@ -122,7 +140,6 @@ FW_VERSIONS = {
     # 2018 Crosstrek - UDM / @rwalsh3 (new engine fw)
     # 2019 Crosstrek - UDM / @Nooks Cranny
     # Ecu, addr, subaddr: ROM ID
-    # 2021 Impreza - AUDM / @letsdudiss
     (Ecu.esp, 0x7b0, None): [
       b'\x7a\x94\x3f\x90\x00',
       b'\xa2 \x185\x00',
@@ -130,7 +147,6 @@ FW_VERSIONS = {
       b'z\x94.\x90\x00',
       b'z\x94\b\x90\x01',
       b'\xa2 \x19`\x00',
-      b'\xa2 !5\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x7a\xc0\x0c\x00',
@@ -139,7 +155,6 @@ FW_VERSIONS = {
       b'z\xc0\x04\x00',
       b'z\xc0\x00\x00',
       b'\x8a\xc0\x10\x00',
-      b'\x9a\xc0\b\x00',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00d\xb5\x1f@ \x0e',
@@ -147,7 +162,6 @@ FW_VERSIONS = {
       b'\x00\x00e\x1c\x1f@ \x14',
       b'\x00\x00d)\x1f@ \a',
       b'\x00\x00e+\x1f@ \x14',
-      b'\xf1\x00\x00\x00\x02',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xaa\x61\x66\x73\x07',
@@ -158,7 +172,6 @@ FW_VERSIONS = {
       b'\xaa!dq\a',
       b'\xaa!dt\a',
       b'\xc5!dr\a',
-      b'\xcaac0\a',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xe3\xe5\x46\x31\x00',
@@ -168,7 +181,6 @@ FW_VERSIONS = {
       b'\xe3\xf5\a\x00\x00',
       b'\xe3\xf5C\x00\x00',
       b'\xe5\xf5B\x00\x00',
-      b'\xe6\x15\x042\x00',
     ],
   },
   CAR.FORESTER_PREGLOBAL: {
@@ -320,6 +332,7 @@ FW_VERSIONS = {
 STEER_THRESHOLD = {
   CAR.ASCENT: 80,
   CAR.IMPREZA: 80,
+  CAR.IMPREZA_2020_2021: 80,
   CAR.FORESTER: 80,
   CAR.FORESTER_HYBRID: 80,
   CAR.FORESTER_PREGLOBAL: 75,
@@ -331,6 +344,7 @@ STEER_THRESHOLD = {
 DBC = {
   CAR.ASCENT: dbc_dict('subaru_global_2017_generated', None),
   CAR.IMPREZA: dbc_dict('subaru_global_2017_generated', None),
+  CAR.IMPREZA_2020_2021: dbc_dict('subaru_global_2017_generated', None),
   CAR.FORESTER: dbc_dict('subaru_global_2017_generated', None),
   CAR.FORESTER_HYBRID: dbc_dict('subaru_global_2020_hybrid_generated', None),
   CAR.FORESTER_PREGLOBAL: dbc_dict('subaru_forester_2017_generated', None),
@@ -340,3 +354,4 @@ DBC = {
 }
 
 PREGLOBAL_CARS = [CAR.FORESTER_PREGLOBAL, CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018]
+REDUCED_TORQUE_CARS = [CAR.IMPREZA_2020_2021]

--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -122,6 +122,7 @@ FW_VERSIONS = {
     # 2018 Crosstrek - UDM / @rwalsh3 (new engine fw)
     # 2019 Crosstrek - UDM / @Nooks Cranny
     # Ecu, addr, subaddr: ROM ID
+    # 2021 Impreza - AUDM / @letsdudiss
     (Ecu.esp, 0x7b0, None): [
       b'\x7a\x94\x3f\x90\x00',
       b'\xa2 \x185\x00',
@@ -129,6 +130,7 @@ FW_VERSIONS = {
       b'z\x94.\x90\x00',
       b'z\x94\b\x90\x01',
       b'\xa2 \x19`\x00',
+      b'\xa2 !5\x00',
     ],
     (Ecu.eps, 0x746, None): [
       b'\x7a\xc0\x0c\x00',
@@ -137,6 +139,7 @@ FW_VERSIONS = {
       b'z\xc0\x04\x00',
       b'z\xc0\x00\x00',
       b'\x8a\xc0\x10\x00',
+      b'\x9a\xc0\b\x00',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00d\xb5\x1f@ \x0e',
@@ -144,6 +147,7 @@ FW_VERSIONS = {
       b'\x00\x00e\x1c\x1f@ \x14',
       b'\x00\x00d)\x1f@ \a',
       b'\x00\x00e+\x1f@ \x14',
+      b'\xf1\x00\x00\x00\x02',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xaa\x61\x66\x73\x07',
@@ -154,6 +158,7 @@ FW_VERSIONS = {
       b'\xaa!dq\a',
       b'\xaa!dt\a',
       b'\xc5!dr\a',
+      b'\xcaac0\a',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xe3\xe5\x46\x31\x00',
@@ -163,6 +168,7 @@ FW_VERSIONS = {
       b'\xe3\xf5\a\x00\x00',
       b'\xe3\xf5C\x00\x00',
       b'\xe5\xf5B\x00\x00',
+      b'\xe6\x15\x042\x00',
     ],
   },
   CAR.FORESTER_PREGLOBAL: {


### PR DESCRIPTION
Added support for Impreza MY20 and MY21.
Impreza_2020_2021 entry in FPv2 is added and belongs to REDUCED_TORQUE_CARS list in values.py.
carcontrollers will check REDUCED_TORQUE_CARS list and apply reduced torque limit accordingly.

Credits: 1will, <-GoldSkis->, Michael, mlp