### PR TITLE
2015 Subaru Legacy 3.6R Limited

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -194,26 +194,35 @@ FW_VERSIONS = {
   CAR.LEGACY_PREGLOBAL: {
     # 2018 Subaru Legacy 2.5i Premium - UDM / @kram322
     # 2016 Subaru Legacy - UDM / @nort
+    # 2015 Subaru Legacy 3.6R Limited / @chrissantamaria
     # Ecu, addr, subaddr: ROM ID
     (Ecu.esp, 0x7b0, None): [
       b'\x8b\x97D\x00',
       b'k\x97D\x00',
+      b'[\xba\xc4\x03'
     ],
     (Ecu.eps, 0x746, None): [
       b'{\xb0\x00\x00',
       b'[\xb0\x00\x01',
+      b'K\xb0\x00\x01'
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00df\x1f@ \n',
       b'\x00\x00c\xb7\x1f@\x10\x16',
+      b'\x00\x00c\x94\x1f@\x10\x08'
+    ],
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\x00\x00\x00'
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xb5\"@p\a',
       b'\xab*@r\a',
+      b'\xa0+@p\x07'
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xbc\xf2\x00\x81\x00',
       b'\xbe\xf2\x00p\x00',
+      b'\xbf\xfb\xc0\x80\x00'
     ],
   },
   CAR.OUTBACK_PREGLOBAL: {


### PR DESCRIPTION
Adds a FPv2 for the 2015 Subaru Legacy 3.6R Limited. My initial test grabbing `carFw` values using the [suggested fingerprinting method](https://github.com/commaai/openpilot/wiki/Fingerprinting#step-1--record-a-drive) was unsuccessful, but using the [alternative method](https://github.com/commaai/openpilot/wiki/Fingerprinting#fingerprinting-20-alternative) worked great.

I added a new `Ecu.fwdRadar` section, not sure if that will interfere with other models.

Wasn't quite sure what the UDM next to other models meant, just omitted for mine.