### PR TITLE
Adding FPv2  for 2019 Subaru outback

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -287,6 +287,7 @@ FW_VERSIONS = {
     # 2018 Outback 3.6r USDM / @Scripty_
     # 2018 Subaru Outback 2.0d - ADM / @Richo
     # 2019 Outback 2.5i Premium / @Z-dawg Swizzlepants
+    # 2019 Outback 2.5i / @dragonmeteor
     # Ecu, addr, subaddr: ROM ID
     (Ecu.esp, 0x7b0, None): [
       b'\x8b\x97\xac\x00',
@@ -294,10 +295,12 @@ FW_VERSIONS = {
       b'\x9b\x97\xac\x00',
       b'\x8b\x97\xbc\x00',
       b'\x8b\x99\xac\x00',
+      b'\x9b\x97\xac\000',
     ],
     (Ecu.eps, 0x746, None): [
       b'{\xb0\x00\x00',
       b'{\xb0\x00\x01',
+      b'{\xb0\000\000',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00df\x1f@ \n',
@@ -305,6 +308,7 @@ FW_VERSIONS = {
       b'\x00\x00d\x95\x00\x00\x00\x00',
       b'\x00\x00d\x95\x1f@ \x0f',
       b'\x00\x00d\xfe\x00\x00\x00\x00',
+      b'\000\000d\xfe\000\000\000\000',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'\xb5"@p\a',
@@ -313,6 +317,7 @@ FW_VERSIONS = {
       b'\xc4"@0\a',
       b'\xb5b@1\x07',
       b'\xb5q\xe0@\a',
+      b'\xc4\"@0\a',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xbc\xf2@\x81\x00',
@@ -322,6 +327,7 @@ FW_VERSIONS = {
       b'\xbc\xe2@\x80\x00',
       b'\xbc\xfb\xe0`\x00',
       b'\xbc\xaf\xe0`\x00',
+      b'\xbb\xf2@`\000',
     ],
   },
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_routes.py](../../selfdrive/test/test_routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->


Updating all the fields of FPv2 for a 2019 Outback.
All updated values are not duplicated in any of the previous fwVersion.
