### PR TITLE
FP2 needed for my 2018 Crosstrek Limited

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -123,6 +123,7 @@ FW_VERSIONS = {
       b'z\x94\f\x90\001',
     ],
     (Ecu.eps, 0x746, None): [
+      b'z\xc0\004\000',
       b'\x7a\xc0\x0c\x00',
       b'z\xc0\b\x00',
       b'\x8a\xc0\x00\x00',


### PR DESCRIPTION
**Description**
Using "subaru-PR-test", and my 2018 Crosstrek was not getting identified correctly. So I did an FP2 and the only diff needed was one more FP2 code added to the Ecu.eps subsection.
**Verification**
Several drives, checking the "platform" result on my.comma.ai, and the route table is now always "SUBARU IMPREZA LIMITED 2019" for my car.