### PR TITLE
first draft working retune for my crosstrek. primarily actuator delay

### DIFF
--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -49,10 +49,10 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.67
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 15
-      ret.steerActuatorDelay = 0.4   # end-to-end angle controller
-      ret.lateralTuning.pid.kf = 0.00005
-      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
+      ret.steerActuatorDelay = 0.18   # end-to-end angle controller
+      ret.lateralTuning.pid.kf = 0.0003
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 32.], [0., 32.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.03, 0.06]]
 
     if candidate == CAR.FORESTER:
       ret.mass = 1568. + STD_CARGO_KG


### PR DESCRIPTION
I was messing with the basePoints as well, bumped to about 70mph. seemed strange that the interpolation stopped at ~45mph before. 

Otherwise this is a tune that is working pretty well on my crosstrek which was having a slow weave/drift on the Hwy @ 70+mph 
It was also previously taking turns late (Actuator delay seemed to take care of that.) 

If this tune doesn't work for you then we could try just adjusting the Actuator Delay. (0.2 was still a touch late for me.  0.15 was cutting the corner) 0.18 seemed about right. 

 I started with Actuator delay watching the timing on OP taking a corner/turn. 
FF alone should be an open loop controller so,
Then I bumped "FF" up until it oversteered and brought it back down. 

I then bumped "P" up until it oversteered and brought it back down. 
I did not do a lot to "I" yet but bumping it up helped smooth out the straight line performance so far. 

I also will need to try more P/I values at highway speed. I checked them to make sure it was performing well but did not do a second set of tuning for the 32m/s breakpoint I have currently. 
