### PR TITLE
Added firmware version for my 2018 Crosstrek Limited to the

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -125,6 +125,7 @@ FW_VERSIONS = {
       b'\xaa!`u\a',
       b'\xaa!dq\a',
       b'\xaa!dt\a',
+      b'\xaa!dt\x07',
       b'\xf1\x00\xa2\x10\t'
       b'\xc5!dr\a',
       b'\xc5!ar\a',


### PR DESCRIPTION
This PR only adds the engine firmware version for my 2018 Crosstrek Limited; it's the only part of my car's fingerprint that wasn't already in car/subaru/values.py.